### PR TITLE
feat(commiting as claude): commit author += "(claude-code)" like Aider does.

### DIFF
--- a/.claude/commands/prime_commit_as_claude.md
+++ b/.claude/commands/prime_commit_as_claude.md
@@ -1,0 +1,3 @@
+# Context Prime
+
+When you commit, add (claude-code) to author name, by using : `GIT_AUTHOR_NAME="$(git config user.name) (claude-code)" git commit`


### PR DESCRIPTION
Add "(claude-code)" to commit's author like Aider does.

Related issues :
* https://github.com/anthropics/claude-code/issues/1105
* https://github.com/openai/codex/issues/938