### PR TITLE
Fix missing output capture

### DIFF
--- a/claude_code_is_programmable_2.py
+++ b/claude_code_is_programmable_2.py
@@ -14,6 +14,12 @@ THEN GIT stage, commit and SWITCH back to main.
 
 command = ["claude", "-p", prompt, "--allowedTools", "Edit", "Bash", "Write"]
 
-process = subprocess.run(command, check=True)
+# Capture Claude's output so we can display it
+process = subprocess.run(
+    command,
+    check=True,
+    capture_output=True,
+    text=True,
+)
 
 print(f"Claude process exited with output: {process.stdout}")


### PR DESCRIPTION
## Summary
- capture output from subprocess in `claude_code_is_programmable_2.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`