### PR TITLE
Add basic pytest framework example

### DIFF
--- a/claude_testing_v1.py
+++ b/claude_testing_v1.py
@@ -1,0 +1,34 @@
+import json
+import subprocess
+from typing import List, Optional
+
+
+def run_claude(
+    prompt: str,
+    output_format: str = "json",
+    allowed_tools: Optional[List[str]] = None,
+    cli: str = "claude",
+) -> str:
+    """Run Claude Code in headless mode with the given output format."""
+    cmd = [cli, "-p", prompt, "--output-format", output_format]
+    if allowed_tools:
+        cmd.extend(["--allowedTools", *allowed_tools])
+    result = subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"claude failed: {result.stderr}")
+    return result.stdout
+
+
+def run_claude_json(
+    prompt: str,
+    allowed_tools: Optional[List[str]] = None,
+    cli: str = "claude",
+) -> dict:
+    """Run Claude and parse JSON output."""
+    output = run_claude(prompt, "json", allowed_tools, cli)
+    return json.loads(output)

--- a/tests/test_claude_testing_v1.py
+++ b/tests/test_claude_testing_v1.py
@@ -1,0 +1,17 @@
+import os
+import shutil
+import json
+import pytest
+from claude_testing_v1 import run_claude_json
+
+
+CLAUDE_AVAILABLE = shutil.which("claude") is not None
+
+skip_reason = "claude CLI not available or RUN_CLAUDE_TESTS not set"
+
+@pytest.mark.skipif(not CLAUDE_AVAILABLE or os.environ.get("RUN_CLAUDE_TESTS") != "1", reason=skip_reason)
+def test_run_claude_json():
+    """Basic validation that Claude returns valid JSON using --output-format."""
+    output = run_claude_json("hello", allowed_tools=["Bash"])
+    assert isinstance(output, dict)
+    assert output


### PR DESCRIPTION
## Summary
- introduce `claude_testing_v1.py` helper for invoking Claude Code with `--output-format`
- add sample pytest `tests/test_claude_testing_v1.py`

## Testing
- `pytest -q` *(fails: command not found)*